### PR TITLE
Add lv2:min & lv2:max values to the controlmode port for correctly

### DIFF
--- a/so-404.ttl
+++ b/so-404.ttl
@@ -38,6 +38,8 @@
     lv2:portProperty lv2:toggled;
     lv2:portProperty lv2:enumeration;
     lv2:default 0;
+    lv2:minimum 0;
+    lv2:maximum 1;
     lv2:scalePoint [ rdfs:label "Control Ports"; rdf:value 1 ];
     lv2:scalePoint [ rdfs:label "Midi Commands"; rdf:value 0 ];
     ],[

--- a/so-666.ttl
+++ b/so-666.ttl
@@ -38,6 +38,8 @@
     lv2:portProperty lv2:toggled;
     lv2:portProperty lv2:enumeration;
     lv2:default 0;
+    lv2:minimum 0;
+    lv2:maximum 1;
     lv2:scalePoint [ rdfs:label "Control Ports"; rdf:value 1 ];
     lv2:scalePoint [ rdfs:label "Midi Commands"; rdf:value 0 ];
     ],[

--- a/so-kl5.ttl
+++ b/so-kl5.ttl
@@ -38,6 +38,8 @@
     lv2:portProperty lv2:toggled;
     lv2:portProperty lv2:enumeration;
     lv2:default 0;
+    lv2:minimum 0;
+    lv2:maximum 1;
     lv2:scalePoint [ rdfs:label "Control Ports"; rdf:value 1 ];
     lv2:scalePoint [ rdfs:label "Midi Commands"; rdf:value 0 ];
     ],[


### PR DESCRIPTION
working with Jalv host (and probably others).