### PR TITLE
make install honour the PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
+PREFIX ?= /usr
+LV2_DIR ?= /lib/lv2
 OBJECTS = so-666.o so-kl5.o so-404.o sosynth.o
 LIBRARY = libsosynth.so
 TTLS = so-666.ttl so-kl5.ttl so-404.ttl manifest.ttl
 CC = gcc
 CFLAGS += -Wall -O3 -ffast-math -lm `pkg-config --cflags --libs lv2` -fPIC
-INSTALLDIR = $(DESTDIR)/usr/lib/lv2/
+INSTALLDIR = $(DESTDIR)$(PREFIX)$(LV2_DIR)/
 INSTALLNAME = so-synth.lv2/
 $(LIBRARY) : $(OBJECTS)
 	$(CC) $(CFLAGS) $(OBJECTS) -shared -o $@


### PR DESCRIPTION
Also you can set LV2_DIR to decide where to put the lv2 in the prefix

This allow telling where to install the LV2 plugins, while still having the same default.